### PR TITLE
Renamed the field of Redacted<T> to `sensitive`

### DIFF
--- a/galvyn-core/src/misc/redacted/mod.rs
+++ b/galvyn-core/src/misc/redacted/mod.rs
@@ -17,9 +17,9 @@ mod std_impls;
 ///
 /// # Why
 ///
-/// This is useful to mark sensitiv values in the typesystem and prevent accidental leaks to logging.
+/// This is useful to mark sensitive values in the typesystem and prevent accidental leaks to logging.
 ///
-/// A sensitiv value might for example be a secret or a person's data protected by law.
+/// A sensitive value might for example be a secret or a person's data protected by law.
 ///
 /// # How
 ///
@@ -36,24 +36,25 @@ pub struct Redacted<T, Config = Fully> {
     /// Accessing it is not directly dangerous but should be done with care, not to leak it.
     ///
     /// # Don't:
+    ///
     /// ```rust
     /// # use galvyn_core::misc::redacted::Redacted;
     /// #
     /// let secret = Redacted::new("very secret");
-    /// println!("{}", secret.sensitif); // Leak to stdout
+    /// println!("{}", secret.sensitive); // Leak to stdout
     /// ```
     ///
-    /// # Do
+    /// # Do:
     ///
     /// ```rust
     /// # use galvyn_core::misc::redacted::Redacted;
     /// #
     /// let secret = Redacted::new("very secret");
-    /// is_valid(&secret.sensitiv); // Check the actual value
+    /// is_valid(&secret.sensitive); // Check the actual value
     /// // Of course, `is_valid` should not leak the secret either.
     /// // Ideally you carry the `Redacted` type through your code as long as possible.
     /// ```
-    pub sensitiv: T,
+    pub sensitive: T,
     config: PhantomData<Config>,
 }
 
@@ -66,7 +67,7 @@ where
     /// What trait is redacted to what degree is subject to the generic `Config`.
     pub const fn new(value: T) -> Self {
         Self {
-            sensitiv: value,
+            sensitive: value,
             config: PhantomData,
         }
     }

--- a/galvyn-core/src/misc/redacted/serde_impls.rs
+++ b/galvyn-core/src/misc/redacted/serde_impls.rs
@@ -38,9 +38,9 @@ where
         };
 
         if matches!(part_to_redact, PartToRedact::Nothing) {
-            self.sensitiv.serialize(serializer)
+            self.sensitive.serialize(serializer)
         } else {
-            self.sensitiv.serialize(RedactingSerializer {
+            self.sensitive.serialize(RedactingSerializer {
                 inner: serializer,
                 part_to_redact,
             })
@@ -64,7 +64,7 @@ where
     where
         D: Deserializer<'de>,
     {
-        T::deserialize_in_place(deserializer, &mut place.sensitiv)
+        T::deserialize_in_place(deserializer, &mut place.sensitive)
     }
 }
 

--- a/galvyn-core/src/misc/redacted/std_impls.rs
+++ b/galvyn-core/src/misc/redacted/std_impls.rs
@@ -22,7 +22,7 @@ where
         if matches!(part_to_redact, PartToRedact::Everything) {
             f.write_str("-redacted-")
         } else {
-            let value = format!("{:?}", self.sensitiv);
+            let value = format!("{:?}", self.sensitive);
             f.write_str(part_to_redact.redact(&value).as_ref())
         }
     }
@@ -39,7 +39,7 @@ where
         if matches!(part_to_redact, PartToRedact::Everything) {
             f.write_str("-redacted-")
         } else {
-            let value = format!("{}", self.sensitiv);
+            let value = format!("{}", self.sensitive);
             f.write_str(part_to_redact.redact(&value).as_ref())
         }
     }
@@ -52,13 +52,13 @@ where
 {
     fn clone(&self) -> Self {
         Self {
-            sensitiv: self.sensitiv.clone(),
+            sensitive: self.sensitive.clone(),
             config: PhantomData,
         }
     }
 
     fn clone_from(&mut self, source: &Self) {
-        self.sensitiv.clone_from(&source.sensitiv)
+        self.sensitive.clone_from(&source.sensitive)
     }
 }
 impl<T, Config> Eq for Redacted<T, Config> where T: Eq {}
@@ -67,7 +67,7 @@ where
     T: PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
-        self.sensitiv.eq(&other.sensitiv)
+        self.sensitive.eq(&other.sensitive)
     }
 }
 impl<T, Config> Ord for Redacted<T, Config>
@@ -75,7 +75,7 @@ where
     T: Ord,
 {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.sensitiv.cmp(&other.sensitiv)
+        self.sensitive.cmp(&other.sensitive)
     }
 }
 impl<T, Config> PartialOrd for Redacted<T, Config>
@@ -83,7 +83,7 @@ where
     T: PartialOrd,
 {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.sensitiv.partial_cmp(&other.sensitiv)
+        self.sensitive.partial_cmp(&other.sensitive)
     }
 }
 impl<T, Config> Hash for Redacted<T, Config>
@@ -91,6 +91,6 @@ where
     T: Hash,
 {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.sensitiv.hash(state)
+        self.sensitive.hash(state)
     }
 }


### PR DESCRIPTION
This fixes a typo.

This is a breaking change for all consumers of the Redacted type.